### PR TITLE
Add __threadfence() to bottom-up construction kernel.

### DIFF
--- a/lbvh/bvh.cuh
+++ b/lbvh/bvh.cuh
@@ -419,6 +419,8 @@ class bvh {
                     const auto rbox = self.aabbs[ridx];
                     self.aabbs[parent] = merge(lbox, rbox);
 
+                    __threadfence();
+
                     // look the next parent...
                     parent = self.nodes[parent].parent_idx;
                 }


### PR DESCRIPTION
Hi! This PR addresses a long-standing and hard-to-find thread-safety bug in lbvh, which causes nodes in the BVH tree to randomly disappear in large scenes. I submit a PR here first, and later I'll submit one in the upstream version as well.

Thanks!